### PR TITLE
Improve clarity, particularly in Obelisk.Document

### DIFF
--- a/lib/mix/tasks/perf.ex
+++ b/lib/mix/tasks/perf.ex
@@ -15,16 +15,17 @@ defmodule Mix.Tasks.Perf do
   end
 
   defp make_10k_posts do
-    1..10_000 |> Enum.each &(create_post &1)
+    1..10_000 |> Enum.each(&create_post(&1))
   end
 
   defp filename(num) do
     today = Chronos.today
+
     "#{Chronos.Formatter.strftime today, "%y-%0m-%0d"}-post-#{num}.markdown"
   end
 
   defp create_post(num) do
-    File.write("./posts/#{filename(num)}.markdown", content)
+    File.write "./posts/#{filename(num)}.markdown", content
   end
 
   defp content do

--- a/lib/obelisk/draft.ex
+++ b/lib/obelisk/draft.ex
@@ -5,7 +5,11 @@ defmodule Obelisk.Draft do
   end
 
   def title(md) do
-    String.capitalize(String.replace(String.replace(String.slice(md, 11, 1000), "-", " "), ".markdown", ""))
+    md
+    |> String.slice(11, 1000)
+    |> String.replace("-", " ")
+    |> String.replace(".markdown", "")
+    |> String.capitalize
   end
 
   def list do
@@ -13,12 +17,16 @@ defmodule Obelisk.Draft do
   end
 
   def create(title) do
-    File.write(filename_from_title(title), Obelisk.Templates.post(title))
+    File.write filename_from_title(title), Obelisk.Templates.post(title)
   end
 
   def filename_from_title(title) do
     datepart = Chronos.today |> Chronos.Formatter.strftime("%Y-%0m-%0d")
-    titlepart = String.downcase(title) |> String.replace(" ", "-")
+    titlepart =
+      title
+      |> String.downcase
+      |> String.replace(" ", "-")
+
     "./drafts/#{datepart}-#{titlepart}.markdown"
   end
 

--- a/lib/obelisk/page.ex
+++ b/lib/obelisk/page.ex
@@ -8,6 +8,7 @@ defmodule Obelisk.Page do
 
   def prepare(md_file, store) do
     layouts = Obelisk.Store.get_layouts(store)
+
     Obelisk.Store.add_pages(store, [ Obelisk.Document.prepare("./pages/#{md_file}", layouts.page) ])
   end
 
@@ -16,11 +17,15 @@ defmodule Obelisk.Page do
   end
 
   def create(title) do
-    File.write(filename_from_title(title), Obelisk.Templates.page(title))
+    File.write filename_from_title(title), Obelisk.Templates.page(title)
   end
 
   def filename_from_title(title) do
-    titlepart = String.downcase(title) |> String.replace(" ", "-")
+    titlepart =
+      title
+      |> String.downcase
+      |> String.replace(" ", "-")
+
     "./pages/#{titlepart}.markdown"
   end
 

--- a/lib/obelisk/post.ex
+++ b/lib/obelisk/post.ex
@@ -8,11 +8,16 @@ defmodule Obelisk.Post do
 
   def prepare(md_file, store) do
     layouts = Obelisk.Store.get_layouts(store)
+
     Obelisk.Store.add_posts(store, [ Obelisk.Document.prepare("./posts/#{md_file}", layouts.post) ])
   end
 
   def title(md) do
-    String.capitalize(String.replace(String.replace(String.slice(md, 11, 1000), "-", " "), ".markdown", ""))
+    md
+    |> String.slice(11, 1000)
+    |> String.replace("-", " ")
+    |> String.replace(".markdown", "")
+    |> String.capitalize
   end
 
   def list do
@@ -22,12 +27,16 @@ defmodule Obelisk.Post do
   end
 
   def create(title) do
-    File.write(filename_from_title(title), Obelisk.Templates.post(title))
+    File.write filename_from_title(title), Obelisk.Templates.post(title)
   end
 
   def filename_from_title(title) do
     datepart = Chronos.today |> Chronos.Formatter.strftime("%Y-%0m-%0d")
-    titlepart = String.downcase(title) |> String.replace(" ", "-")
+    titlepart =
+      title
+      |> String.downcase
+      |> String.replace(" ", "-")
+
     "./posts/#{datepart}-#{titlepart}.markdown"
   end
 

--- a/lib/obelisk/renderer.ex
+++ b/lib/obelisk/renderer.ex
@@ -1,8 +1,12 @@
 defmodule Obelisk.Renderer do
 
+  def render(content), do: Earmark.to_html(content)
+
+  def render({template,  :eex}, params), do: EEx.eval_string(template, assigns: params)
+  def render({template, :haml}, params), do: Calliope.render(template, params)
   def render(content, format), do: render(content, [], format)
 
-  def render(content, params, :eex), do: EEx.eval_string(content, assigns: params)
+  def render(content, params,  :eex), do: EEx.eval_string(content, assigns: params)
   def render(content, params, :haml), do: Calliope.render(content, params)
 
 end

--- a/lib/obelisk/rss.ex
+++ b/lib/obelisk/rss.ex
@@ -12,7 +12,7 @@ defmodule Obelisk.RSS do
   end
 
   defp compile_rss(posts) do
-    posts |> Enum.map &(build_item &1)
+    posts |> Enum.map(&build_item(&1))
   end
 
   defp build_item(post) do

--- a/lib/obelisk/tasks/server.ex
+++ b/lib/obelisk/tasks/server.ex
@@ -13,7 +13,7 @@ defmodule Obelisk.Tasks.Server do
     Application.start :plug
     IO.puts "Starting Cowboy server. Browse to http://localhost:4000/"
     IO.puts "Press <CTRL+C> <CTRL+C> to quit."
-    { :ok, pid } = Plug.Adapters.Cowboy.http Obelisk.Plug.Server, []
+    { :ok, _pid } = Plug.Adapters.Cowboy.http Obelisk.Plug.Server, []
 
     :timer.sleep(:infinity)
   end

--- a/test/renderer_test.exs
+++ b/test/renderer_test.exs
@@ -40,5 +40,24 @@ defmodule RendererTest do
     assert expected == result
   end
 
+  test "Test render/2 eex with parameters" do
+    title = "Good morning"
+    content = "<h1><%= @title %></h1>"
+    expected = "<h1>Good morning</h1>"
+
+    result = Renderer.render({content, :eex}, [title: title])
+
+    assert expected == result
+  end
+
+  test "Test render/2 haml with parameters" do
+    title = "Good morning"
+    content = "%h1= title"
+    expected = "<h1>Good morning</h1>"
+
+    result = Renderer.render({content, :haml}, [title: title])
+
+    assert expected == result
+  end
 
 end


### PR DESCRIPTION
  * Broke compile/2 and prepare/2 into smaller pieces, emphasizing common patterns
  * Expanded Obelisk.Renderer.render API to accept combined layout tuple
  * Expanded Obelisk.Renderer.render API to handle Earmark call
  * Added tests for expanded Obelisk.Renderer.render API
  * Changed highly nested calls in title/1 to pipes
  * Made minor refactorings to prevent warnings in later Elixir versions