### PR TITLE
Update gitignore on an new project

### DIFF
--- a/lib/obelisk/site.ex
+++ b/lib/obelisk/site.ex
@@ -5,6 +5,13 @@ defmodule Obelisk.Site do
     create_content_dirs
     Obelisk.Post.create("Welcome to Obelisk")
     File.write './site.yml', Obelisk.Templates.config
+
+    update_gitignore
+  end
+
+  def test_setup(dir) do
+    File.cd(dir)
+    initialize
   end
 
   def clean do
@@ -39,6 +46,12 @@ defmodule Obelisk.Site do
     File.write "./themes/default/layout/layout.eex", Obelisk.Templates.layout
     File.write "./themes/default/layout/index.eex", Obelisk.Templates.index
     File.write "./themes/default/layout/page.eex", Obelisk.Templates.page_template
+  end
+
+  defp update_gitignore do
+    File.open("./.gitignore", [:append], fn(file) ->
+      IO.binwrite(file, "\n/build\n")
+    end)
   end
 
 end

--- a/test/init_test.exs
+++ b/test/init_test.exs
@@ -2,43 +2,40 @@ defmodule InitTaskTest do
   use ExUnit.Case, async: false
 
   setup do
+    Obelisk.Site.test_setup(System.tmp_dir)
+
     on_exit fn -> TestHelper.cleanup end
   end
 
   test "Init task creates assets directory structure" do
-    Obelisk.Tasks.Init.run([])
+    dirs = ~w(./themes ./themes/default ./themes/default/assets ./themes/default/assets/css
+        ./themes/default/assets/js ./themes/default/assets/img ./themes/default/assets/css/base.css
+        ./themes/default/layout)
+    Enum.each(dirs, fn(dir) -> File.dir? dir |> assert end)
 
-    assert File.dir? "./themes"
-    assert File.dir? "./themes/default"
-    assert File.dir? "./themes/default/assets"
-    assert File.dir? "./themes/default/assets/css"
-    assert File.dir? "./themes/default/assets/js"
-    assert File.dir? "./themes/default/assets/img"
-    assert File.exists? "./themes/default/assets/css/base.css"
-
-    assert File.dir? "./themes/default/layout"
-    assert File.exists? "./themes/default/layout/layout.eex"
-    assert File.exists? "./themes/default/layout/post.eex"
-    assert File.exists? "./themes/default/layout/page.eex"
+    files = ~w(./themes/default/layout/layout.eex ./themes/default/layout/post.eex
+    ./themes/default/layout/page.eex)
+    Enum.each(files, fn(file) -> File.exists?(file) |> assert end)
   end
 
   test "Init task creates content directory structure" do
-    Obelisk.Tasks.Init.run([])
-
     assert File.dir? "./posts"
     assert File.dir? "./drafts"
     assert File.dir? "./pages"
   end
 
   test "Init task creates initial config file" do
-    Obelisk.Tasks.Init.run([])
-
     assert File.exists? "./site.yml"
   end
 
   test "Init task creates first post" do
-    Obelisk.Tasks.Init.run([])
-
     assert File.exists? "./posts/#{TestHelper.datepart}-welcome-to-obelisk.markdown"
+  end
+
+  test "appends the build dir to the .gitignore" do
+    assert File.exists?(".gitignore")
+    { :ok, file } = File.read(".gitignore")
+
+    assert String.match?(file, ~r/build\n\z/)
   end
 end


### PR DESCRIPTION
When a new blog is started the `build` folder should be ignored and if deployed generated, but changes in the folder shouldn't mark the git dir as dirty.