### PR TITLE
update obelisk version in docs to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We then modify our dependencies within `mix.exs` to include obelisk, as well as 
 library yamerl.
 
     defp deps do
-      [{ :obelisk, "~> 0.7.1" },
+      [{ :obelisk, "~> 0.10.0" },
        { :yamerl, github: "yakaz/yamerl"}]
     end
 


### PR DESCRIPTION
0.7.1 looks pretty outdated. bumping to 0.10.0
0.7.1 also doesn't compile with latest elixir, etc. This broke me when I tried to get started tonight.